### PR TITLE
Versionamento e suporte Laravel e informação CSP

### DIFF
--- a/LibraryReleases.md
+++ b/LibraryReleases.md
@@ -5,6 +5,7 @@
 | Bootstrap          | https://getbootstrap.com/docs/versions                              |
 | CentOS             | https://www.centos.org/download/                                    |
 | jQuery             | https://releases.jquery.com                                         |
+| Laravel            | https://laravel.com/docs/12.x/releases#support-policy               |
 | MariaDB            | https://mariadb.com/kb/en/mariadb-server-release-dates/             |
 | Moodle             | https://moodledev.io/general/releases                               |
 | MS .Net            | https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core/ |

--- a/isMyWebsiteInsecure-2.sh
+++ b/isMyWebsiteInsecure-2.sh
@@ -71,7 +71,8 @@ main() {
                          --new-tab "https://www.cookiebot.com/en/compliance-test/?domain=$host" \
                          --new-tab "https://developers.google.com/speed/pagespeed/insights/?url=$url" \
                          --new-tab "https://validator.w3.org/nu/?showsource=no&doc=$url/" \
-                         --new-tab "https://jigsaw.w3.org/css-validator/validator?uri=$url&profile=css3svg&usermedium=all&warning=1&vextwarning=&lang=en"
+                         --new-tab "https://jigsaw.w3.org/css-validator/validator?uri=$url&profile=css3svg&usermedium=all&warning=1&vextwarning=&lang=en" \
+                         --new-tab "https://csp-evaluator.withgoogle.com/"
                          
 }
 


### PR DESCRIPTION
Boa noite @oazevedo ,
Verifiquei que na documentação que contém os links para as versões não tinhas da framework laravel, que é a que estamos a utilizar.

Alterações neste PR
- Link para as versões e suporte Laravel
- Inclusão de uma página da google que dá algumas informações sobre o CSP

Achei que poderia fazer sentido a inclusão desta informação.